### PR TITLE
Fix player dying in sand triggering crash

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -66,7 +66,7 @@ end
 function api.is_owner(pos, name)
 	local player = minetest.get_player_by_name(name)
 
-	if player:get_hp() == 0 then
+	if not player or player:get_hp() == 0 then
 		return false
 	end
 


### PR DESCRIPTION
Fixes
```
2023-04-01 16:00:04: ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod '*builtin*' in callback luaentity_Step(): .../games/mesecraft_centeria/mods/PLAYER
/bones_redo/api.lua:69: attempt to index local 'player' (a nil value)
2023-04-01 16:00:04: ERROR[Main]: stack traceback:
2023-04-01 16:00:04: ERROR[Main]:       .../games/mesecraft_centeria/mods/PLAYER/bones_redo/api.lua:69: in function 'is_owner'
2023-04-01 16:00:04: ERROR[Main]:       ...games/mesecraft_centeria/mods/PLAYER/bones_redo/node.lua:23: in function 'can_dig'
2023-04-01 16:00:04: ERROR[Main]:       .../minetest/centeria/minetest/bin/../builtin/game/item.lua:445: in function 'on_dig'
2023-04-01 16:00:04: ERROR[Main]:       ...netest/centeria/minetest/bin/../builtin/game/falling.lua:280: in function 'try_place'
2023-04-01 16:00:04: ERROR[Main]:       ...netest/centeria/minetest/bin/../builtin/game/falling.lua:389: in function <...netest/centeria/minetest/bin/../builtin/game/f
alling.lua:305>
```